### PR TITLE
Add static placeholder page for Ideas

### DIFF
--- a/frontend/app/ideas/page.tsx
+++ b/frontend/app/ideas/page.tsx
@@ -1,0 +1,23 @@
+export default function IdeasPage() {
+  return (
+    <main className="min-h-screen px-6 py-16">
+      <div className="max-w-3xl mx-auto">
+        <h1 className="text-3xl font-bold mb-4">
+          Ideas in EchoRoom
+        </h1>
+
+        <p className="text-gray-600 text-lg">
+          Ideas are the starting point of learning in EchoRoom.
+          Instead of remaining as suggestions, ideas here are
+          explored through small experiments and reflections.
+        </p>
+
+        <p className="text-gray-600 text-lg mt-4">
+          This is a static placeholder page. In future updates,
+          this section will allow communities to view, discuss,
+          and evolve ideas into experiments.
+        </p>
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
What I changed

Added a new static page at the /ideas route using the Next.js App Router.

Created app/ideas/page.tsx with a heading and placeholder text explaining what “Ideas” mean in EchoRoom.

No forms, no data fetching, no backend changes.

Why this fixes the issue

The issue required a static placeholder page for Ideas.

This PR fulfills that requirement by clearly explaining the role of Ideas in EchoRoom.

Provides a foundation for future features without adding unnecessary complexity.
<img width="1872" height="953" alt="ok" src="https://github.com/user-attachments/assets/a9625448-ac75-40b3-a065-f7608546b22b" />
