### PR TITLE
Add backend placeholder route for experiments

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -12,6 +12,26 @@ app.get("/health", (_req: Request, res: Response) => {
 });
 
 const PORT = 5000;
+app.get("/experiments", (req: Request, res: Response) => {
+  res.json({
+    success: true,
+    experiments: [
+      {
+        id: 1,
+        title: "Community Clean-up Drive",
+        status: "completed",
+        outcome: "Positive participation"
+      },
+      {
+        id: 2,
+        title: "Weekly Knowledge Sharing Session",
+        status: "ongoing",
+        outcome: "High engagement"
+      }
+    ]
+  });
+});
+
 
 app.listen(PORT, () => {
   console.log(`🚀 Backend running on http://localhost:${PORT}`);


### PR DESCRIPTION
What I changed:
- Added a dummy GET /experiments endpoint returning static data

Why this fixes the issue:
- Provides a backend placeholder endpoint without database or authentication as required

Fixes #8
<img width="1512" height="875" alt="Screenshot 2026-02-03 191212" src="https://github.com/user-attachments/assets/c38e4c6b-46a8-43d2-bde8-d31f883f580a" />
