### PR TITLE
Add backend placeholder route for ideas

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,8 +1,10 @@
 import express, { Request, Response } from "express";
+import ideasRoutes from "./routes/ideas.routes";
 
 const app = express();
 
 app.use(express.json());
+app.use("/ideas", ideasRoutes);
 
 app.get("/health", (_req: Request, res: Response) => {
   res.json({

--- a/backend/src/routes/ideas.routes.ts
+++ b/backend/src/routes/ideas.routes.ts
@@ -1,0 +1,25 @@
+import { Router, Request, Response } from "express";
+
+const router = Router();
+
+router.get("/", (req: Request, res: Response) => {
+  res.json({
+    success: true,
+    ideas: [
+      {
+        id: 1,
+        title: "Plant Trees in Campus",
+        description: "Organize a student-led tree plantation drive",
+        status: "proposed"
+      },
+      {
+        id: 2,
+        title: "Peer Learning Circles",
+        description: "Weekly peer-to-peer knowledge sharing sessions",
+        status: "active"
+      }
+    ]
+  });
+});
+
+export default router;


### PR DESCRIPTION
What I changed:
- Added a new backend route file for ideas
- Exposed GET /ideas endpoint returning static mock data

Why this fixes the issue:
- Provides a placeholder ideas API following backend structure without database or authentication

Fixes #7


<img width="1034" height="761" alt="Screenshot 2026-02-03 220014" src="https://github.com/user-attachments/assets/8a6bb95a-bf6e-466d-a4d7-40e869aa7036" />
