### PR TITLE
Create community page to fix /community 404 error (Fixes #38)

### DIFF
--- a/frontend/app/community/page.tsx
+++ b/frontend/app/community/page.tsx
@@ -1,0 +1,28 @@
+export default function CommunityPage() {
+  return (
+    <main className="min-h-screen px-6 py-16">
+      <div className="max-w-3xl mx-auto">
+        <h1 className="text-3xl font-bold mb-4">
+          EchoRoom Community
+        </h1>
+
+        <p className="text-gray-600 text-lg">
+          The EchoRoom community is where learners, builders, and thinkers
+          come together to explore ideas, run experiments, and reflect on
+          their learning journey.
+        </p>
+
+        <p className="text-gray-600 text-lg mt-4">
+          This space will enable collaboration, discussions, and shared
+          learning experiences. Members will be able to contribute ideas,
+          participate in experiments, and grow together as a community.
+        </p>
+
+        <p className="text-gray-600 text-lg mt-4">
+          This is currently a placeholder page. Future updates will include
+          community discussions, contributor profiles, and collaborative tools.
+        </p>
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
This PR creates the Community page for EchoRoom and fixes the /community 404 error.

## Changes made
- Created community folder inside app directory
- Added page.tsx for community route
- Implemented placeholder UI consistent with Ideas and Experiments pages

## Result
Users can now navigate to /community without errors.

Fixes #38
