### PR TITLE
Refactor PostCSS configuration and add custom dark variant to global …

### DIFF
--- a/frontend/postcss.config.mjs
+++ b/frontend/postcss.config.mjs
@@ -1,6 +1,5 @@
-const config = {
+export default {
   plugins: {
     "@tailwindcss/postcss": {},
   },
 };
-export default config;

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -1,5 +1,7 @@
 @import "tailwindcss";
 
+@custom-variant dark (&:where(.dark, .dark *));
+
 /* ========================= */
 /* BASE */
 /* ========================= */


### PR DESCRIPTION
Fixed when swiching themes , dark and light theme

`Light`
<img width="1324" height="613" alt="image" src="https://github.com/user-attachments/assets/f9c535cc-abe2-467c-9957-0440940ed502" />

`Dark`

<img width="1281" height="604" alt="image" src="https://github.com/user-attachments/assets/01aa26ba-b38e-48e5-9d13-f10cbefc707d" />
