### PR TITLE
Implement state transition logic for idea lifecycle (#67)

### DIFF
--- a/backend/test.http
+++ b/backend/test.http
@@ -1,0 +1,28 @@
+### Create Idea
+POST http://localhost:5000/ideas
+Content-Type: application/json
+
+{
+  "title": "Test Idea",
+  "description": "Testing lifecycle"
+}
+
+###
+
+### Move to experiment
+PATCH http://localhost:5000/ideas/3/status
+Content-Type: application/json
+
+{
+  "status": "experiment"
+}
+
+###
+
+###
+PATCH http://localhost:5000/ideas/3/status
+Content-Type: application/json
+
+{
+  "status": "reflection"
+}


### PR DESCRIPTION
## Summary
Implemented lifecycle state transition logic for ideas.

## Changes
- Defined IdeaStatus type
- Defined allowedTransitions map
- Added PATCH /ideas/:id/status endpoint
- Enforced valid transitions
- Prevented invalid transitions

## Lifecycle flow enforced
proposed → experiment → outcome → reflection

## Result
Backend now ensures logical lifecycle progression.
