### PR TITLE
feat: Implement persistent dark mode across all pages

### DIFF
--- a/frontend/app/community/Navbar.tsx
+++ b/frontend/app/community/Navbar.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { Menu, X } from "lucide-react";
+import { useTheme } from "../components/ThemeProvider";
 
 const navLinks = [
   { to: "/ideas", label: "Ideas" },
@@ -14,6 +15,7 @@ const navLinks = [
 export const Navbar = () => {
   const pathname = usePathname();
   const [mobileOpen, setMobileOpen] = useState(false);
+  const { dark, toggleTheme } = useTheme();
 
 return (
   <nav className="sticky top-0 z-50 backdrop-blur-lg bg-white/70 dark:bg-slate-900/70 border-b border-slate-200 dark:border-slate-800">
@@ -24,13 +26,13 @@ return (
       </Link>
 
       {/* Desktop Nav */}
-      <div className="hidden md:flex items-center space-x-8 text-sm font-medium text-muted-foreground">
+      <div className="hidden md:flex items-center space-x-8 text-sm font-medium text-slate-600 dark:text-slate-300">
         {navLinks.map((link) => (
           <Link
             key={link.to}
             href={link.to}
-            className={`transition-colors hover:text-primary ${
-              pathname === link.to ? "text-primary" : ""
+            className={`transition-colors hover:text-blue-600 dark:hover:text-blue-400 ${
+              pathname === link.to ? "text-blue-600 dark:text-blue-400" : ""
             }`}
           >
             {link.label}
@@ -39,15 +41,23 @@ return (
       </div>
 
       <div className="flex items-center space-x-4">
+        <button
+          onClick={toggleTheme}
+          className="w-10 h-10 flex items-center justify-center rounded-full hover:bg-slate-100 dark:hover:bg-slate-800 transition"
+          aria-label="Toggle theme"
+        >
+          {dark ? "☀️" : "🌙"}
+        </button>
+
         <Link href="/community" className="hidden md:inline-flex">
-          <button className="bg-primary hover:bg-primary/90 text-primary-foreground font-medium px-4 py-2 rounded-md">
+          <button className="bg-gradient-to-r from-blue-600 to-indigo-600 text-white font-medium px-4 py-2 rounded-md hover:shadow-lg transition">
             Join Community
           </button>
         </Link>
 
         {/* Mobile menu toggle */}
         <button
-          className="md:hidden text-foreground p-2"
+          className="md:hidden text-slate-900 dark:text-white p-2"
           onClick={() => setMobileOpen(!mobileOpen)}
         >
           {mobileOpen ? <X className="h-5 w-5" /> : <Menu className="h-5 w-5" />}
@@ -57,15 +67,15 @@ return (
 
     {/* Mobile Nav */}
     {mobileOpen && (
-      <div className="md:hidden border-t border-white/10 bg-background pb-4">
+      <div className="md:hidden border-t border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900 pb-4">
         <div className="container flex flex-col space-y-3 pt-4">
           {navLinks.map((link) => (
             <Link
               key={link.to}
               href={link.to}
               onClick={() => setMobileOpen(false)}
-              className={`text-sm font-medium transition-colors hover:text-primary ${
-                pathname === link.to ? "text-primary" : "text-muted-foreground"
+              className={`text-sm font-medium transition-colors hover:text-blue-600 dark:hover:text-blue-400 ${
+                pathname === link.to ? "text-blue-600 dark:text-blue-400" : "text-slate-600 dark:text-slate-300"
               }`}
             >
               {link.label}

--- a/frontend/app/community/PageLayout.tsx
+++ b/frontend/app/community/PageLayout.tsx
@@ -6,7 +6,7 @@ interface PageLayoutProps {
 
 export const PageLayout = ({ children }: PageLayoutProps) => {
   return (
-    <div className="min-h-screen bg-background flex flex-col">
+    <div className="min-h-screen bg-slate-50 dark:bg-slate-900 flex flex-col transition-colors">
 
       <Navbar />
 

--- a/frontend/app/components/ThemeProvider.tsx
+++ b/frontend/app/components/ThemeProvider.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { createContext, useContext, useEffect, useState } from "react";
+
+const ThemeContext = createContext({ dark: false, toggleTheme: () => {} });
+
+export const useTheme = () => useContext(ThemeContext);
+
+export const ThemeProvider = ({ children }: { children: React.ReactNode }) => {
+  const [dark, setDark] = useState(false);
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+    const saved = localStorage.getItem("color-theme");
+    const isDark = saved === "dark" || (!saved && window.matchMedia("(prefers-color-scheme: dark)").matches);
+    setDark(isDark);
+    document.documentElement.classList.toggle("dark", isDark);
+  }, []);
+
+  const toggleTheme = () => {
+    const newDark = !dark;
+    setDark(newDark);
+    localStorage.setItem("color-theme", newDark ? "dark" : "light");
+    document.documentElement.classList.toggle("dark", newDark);
+  };
+
+  if (!mounted) return <>{children}</>;
+
+  return (
+    <ThemeContext.Provider value={{ dark, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};

--- a/frontend/app/experiments/page.tsx
+++ b/frontend/app/experiments/page.tsx
@@ -27,9 +27,9 @@ export default function ExperimentsPage() {
 
   // Status color
   const getStatusTextColor = (status: string) => {
-    if (status === "Completed") return "text-green-600";
-    if (status === "In Progress") return "text-blue-600";
-    return "text-gray-600";
+    if (status === "Completed") return "text-green-600 dark:text-green-400";
+    if (status === "In Progress") return "text-blue-600 dark:text-blue-400";
+    return "text-gray-600 dark:text-gray-400";
   };
 
   // Progress bar color
@@ -46,13 +46,13 @@ export default function ExperimentsPage() {
       <div className="section">
 
         {/* Header */}
-        <div className="section">
+        <div className="mb-8">
 
-          <h1 className="page-title">
+          <h1 className="text-4xl font-bold text-gray-900 dark:text-white mb-3">
             Experiments
           </h1>
 
-          <p className="page-description">
+          <p className="text-lg text-gray-600 dark:text-gray-300 max-w-2xl">
             Track and manage experiments to test ideas and learn quickly.
           </p>
 
@@ -64,11 +64,11 @@ export default function ExperimentsPage() {
 
           <div className="card text-center py-16">
 
-            <h2 className="text-2xl font-semibold mb-2">
+            <h2 className="text-2xl font-semibold text-gray-800 dark:text-white mb-2">
               No experiments yet
             </h2>
 
-            <p className="text-gray-600 mb-4">
+            <p className="text-gray-600 dark:text-gray-300 mb-4">
               Start your first experiment to test and validate ideas.
             </p>
 
@@ -87,11 +87,11 @@ export default function ExperimentsPage() {
 
               <div key={index} className="card">
 
-                <h2 className="text-xl font-semibold mb-2">
+                <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-2">
                   {exp.title}
                 </h2>
 
-                <p className="text-gray-600 mb-4">
+                <p className="text-gray-600 dark:text-gray-300 mb-4">
                   {exp.description}
                 </p>
 
@@ -103,7 +103,7 @@ export default function ExperimentsPage() {
                     Status: {exp.status}
                   </span>
 
-                  <span className="text-sm text-gray-500">
+                  <span className="text-sm text-gray-500 dark:text-gray-400">
                     {exp.progress}%
                   </span>
 
@@ -111,7 +111,7 @@ export default function ExperimentsPage() {
 
 
                 {/* Progress bar */}
-                <div className="w-full bg-gray-200 rounded-full h-2">
+                <div className="w-full bg-gray-200 dark:bg-slate-700 rounded-full h-2">
 
                   <div
                     className={`h-2 rounded-full ${getProgressColor(exp.status)}`}

--- a/frontend/app/ideas/page.tsx
+++ b/frontend/app/ideas/page.tsx
@@ -8,12 +8,12 @@ export default function IdeasPage() {
       <div className="section">
 
         {/* Header */}
-        <div className="section">
-          <h1 className="page-title">
+        <div className="mb-8">
+          <h1 className="text-4xl font-bold text-gray-900 dark:text-white mb-3">
             Ideas in EchoRoom
           </h1>
 
-          <p className="page-description">
+          <p className="text-lg text-gray-600 dark:text-gray-300 max-w-2xl">
             Ideas are the starting point of learning. Communities can share ideas,
             explore them through experiments, and reflect on outcomes.
           </p>
@@ -25,11 +25,11 @@ export default function IdeasPage() {
           /* Empty State */
           <div className="card text-center py-12">
 
-            <h2 className="text-2xl font-semibold text-gray-800 mb-3">
+            <h2 className="text-2xl font-semibold text-gray-800 dark:text-white mb-3">
               No ideas yet
             </h2>
 
-            <p className="text-gray-500 mb-6">
+            <p className="text-gray-500 dark:text-gray-400 mb-6">
               Ideas shared by the community will appear here.
               Be the first to create one.
             </p>
@@ -47,15 +47,15 @@ export default function IdeasPage() {
 
             {ideas.map((idea, index) => (
               <div key={index} className="card">
-                <h3 className="text-xl font-semibold text-gray-900 mb-2">
+                <h3 className="text-xl font-semibold text-gray-900 dark:text-white mb-2">
                   Idea Title
                 </h3>
 
-                <p className="text-gray-600 text-sm mb-4">
+                <p className="text-gray-600 dark:text-gray-300 text-sm mb-4">
                   Idea description will appear here.
                 </p>
 
-                <div className="text-sm text-gray-400">
+                <div className="text-sm text-gray-400 dark:text-gray-500">
                   Created by Community
                 </div>
               </div>

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,4 +1,5 @@
 import "../styles/globals.css";
+import { ThemeProvider } from "./components/ThemeProvider";
 
 export const metadata = {
   title: "EchoRoom",
@@ -12,9 +13,10 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en" suppressHydrationWarning>
-
-      <body className="bg-gray-50 text-gray-900">
-        {children}
+      <body className="bg-gray-50 dark:bg-slate-900 text-gray-900 dark:text-white transition-colors">
+        <ThemeProvider>
+          {children}
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -2,55 +2,23 @@
 
 import { useEffect, useState } from "react";
 import Link from "next/link";
+import { useTheme } from "./components/ThemeProvider";
 
 export default function HomePage() {
-  const [dark, setDark] = useState(false);
-  const [mounted, setMounted] = useState(false);
+  const { dark, toggleTheme } = useTheme();
   const [backendStatus, setBackendStatus] = useState("Checking backend...");
   const [menuOpen, setMenuOpen] = useState(false);
 
   useEffect(() => {
-  setMounted(true);
-
-  const savedTheme = localStorage.getItem("color-theme");
-
-  if (savedTheme === "dark") {
-    document.documentElement.classList.add("dark");
-    setDark(true);
-  } else if (savedTheme === "light") {
-    document.documentElement.classList.remove("dark");
-    setDark(false);
-  } else {
-    const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
-    if (prefersDark) {
-      document.documentElement.classList.add("dark");
-      setDark(true);
-    }
-  }
-
-  fetch("http://localhost:5000/health")
-    .then((res) => res.json())
-    .then((data) => {
-      setBackendStatus("✅ Backend Connected: " + data.message);
-    })
-    .catch(() => {
-      setBackendStatus("❌ Backend Not Connected");
-    });
-}, []);
-
-
-  const toggleTheme = () => {
-    const newDark = !dark;
-    if (newDark) {
-      document.documentElement.classList.add("dark");
-      localStorage.setItem("color-theme", "dark");
-    } else {
-      document.documentElement.classList.remove("dark");
-      localStorage.setItem("color-theme", "light");
-    }
-    setDark(newDark);
-  };
-if (!mounted) return null;
+    fetch("http://localhost:5000/health")
+      .then((res) => res.json())
+      .then((data) => {
+        setBackendStatus("✅ Backend Connected: " + data.message);
+      })
+      .catch(() => {
+        setBackendStatus("❌ Backend Not Connected");
+      });
+  }, []);
 
 return (
 
@@ -92,7 +60,7 @@ return (
         className="w-10 h-10 flex items-center justify-center rounded-full hover:bg-slate-100 dark:hover:bg-slate-800 transition"
         aria-label="Toggle theme"
       >
-        {mounted ? (dark ? "☀️" : "🌙") : "🌙"}
+        {dark ? "☀️" : "🌙"}
       </button>
 
      {/* Signup Link */}

--- a/frontend/app/reflection/page.tsx
+++ b/frontend/app/reflection/page.tsx
@@ -8,9 +8,9 @@ const reflections = [
 ];
 
 const outcomeColors: Record<string, string> = {
-  Success: "text-green-400 bg-green-400/10",
-  Mixed: "text-yellow-400 bg-yellow-400/10",
-  Failed: "text-red-400 bg-red-400/10",
+  Success: "text-green-600 dark:text-green-400 bg-green-100 dark:bg-green-900/30",
+  Mixed: "text-yellow-600 dark:text-yellow-400 bg-yellow-100 dark:bg-yellow-900/30",
+  Failed: "text-red-600 dark:text-red-400 bg-red-100 dark:bg-red-900/30",
 };
 
 const ReflectionPage = () => {
@@ -20,11 +20,11 @@ const ReflectionPage = () => {
       <div className="container py-16">
         <div className="max-w-3xl mx-auto">
           <div className="flex items-center gap-3 mb-6">
-            <BookOpen className="h-8 w-8 text-purple-400" />
-            <h1 className="text-4xl font-bold text-foreground">Reflection</h1>
+            <BookOpen className="h-8 w-8 text-purple-500 dark:text-purple-400" />
+            <h1 className="text-4xl font-bold text-gray-900 dark:text-white">Reflection</h1>
           </div>
 
-          <p className="text-lg text-muted-foreground mb-10">
+          <p className="text-lg text-gray-600 dark:text-gray-300 mb-10">
             Reflection is where learning becomes meaningful.
             Document your thoughts, insights, and lessons learned
             from ideas and experiments.
@@ -32,20 +32,20 @@ const ReflectionPage = () => {
 
           <div className="space-y-6">
             {reflections.map((ref, i) => (
-              <div key={i} className="bg-card border border-white/10 rounded-xl p-6 hover:border-primary/50 transition-colors">
+              <div key={i} className="bg-white dark:bg-slate-800 border border-gray-200 dark:border-slate-700 rounded-xl p-6 hover:border-blue-500 dark:hover:border-blue-400 transition-colors">
                 <div className="flex items-start justify-between mb-3">
-                  <h3 className="text-xl font-semibold text-foreground">{ref.title}</h3>
+                  <h3 className="text-xl font-semibold text-gray-900 dark:text-white">{ref.title}</h3>
                   <span className={`text-xs font-medium px-3 py-1 rounded-full ${outcomeColors[ref.outcome]}`}>
                     {ref.outcome}
                   </span>
                 </div>
-                <div className="bg-secondary/30 border-l-4 border-primary rounded-r-lg p-4 mb-4">
+                <div className="bg-blue-50 dark:bg-blue-900/20 border-l-4 border-blue-500 dark:border-blue-400 rounded-r-lg p-4 mb-4">
                   <div className="flex items-start gap-2">
-                    <MessageSquare className="w-4 h-4 text-primary mt-0.5 shrink-0" />
-                    <p className="text-sm text-foreground/80 italic">"{ref.learning}"</p>
+                    <MessageSquare className="w-4 h-4 text-blue-600 dark:text-blue-400 mt-0.5 shrink-0" />
+                    <p className="text-sm text-gray-700 dark:text-gray-300 italic">"{ref.learning}"</p>
                   </div>
                 </div>
-                <div className="flex justify-between text-xs text-muted-foreground">
+                <div className="flex justify-between text-xs text-gray-500 dark:text-gray-400">
                   <span>By {ref.author}</span>
                   <span>{ref.date}</span>
                 </div>
@@ -53,8 +53,8 @@ const ReflectionPage = () => {
             ))}
           </div>
 
-          <div className="mt-10 bg-card border border-white/10 rounded-xl p-6 text-center">
-            <p className="text-muted-foreground">More reflection features will be available here soon.</p>
+          <div className="mt-10 bg-white dark:bg-slate-800 border border-gray-200 dark:border-slate-700 rounded-xl p-6 text-center">
+            <p className="text-gray-600 dark:text-gray-300">More reflection features will be available here soon.</p>
           </div>
         </div>
       </div>

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -23,15 +23,15 @@ body {
 @layer components {
 
   .page-title {
-    @apply text-4xl font-bold text-gray-900 mb-3;
+    @apply text-4xl font-bold text-gray-900 dark:text-white mb-3;
   }
 
   .page-description {
-    @apply text-lg text-gray-600 mb-8 max-w-2xl;
+    @apply text-lg text-gray-600 dark:text-gray-300 mb-8 max-w-2xl;
   }
 
   .card {
-    @apply bg-white border border-gray-200 rounded-xl p-6 shadow-sm;
+    @apply bg-white dark:bg-slate-800 border border-gray-200 dark:border-slate-700 rounded-xl p-6 shadow-sm;
   }
 
   .btn-primary {
@@ -39,7 +39,7 @@ body {
   }
 
   .btn-secondary {
-    @apply border border-gray-300 text-gray-700 px-5 py-2 rounded-lg hover:bg-gray-100 transition;
+    @apply border border-gray-300 dark:border-slate-600 text-gray-700 dark:text-gray-300 px-5 py-2 rounded-lg hover:bg-gray-100 dark:hover:bg-slate-800 transition;
   }
 
   .section {


### PR DESCRIPTION
## Changes
- ✅ Added ThemeProvider for centralized dark mode state management
- ✅ Added theme toggle button (☀️/🌙) to shared Navbar - visible on all pages
- ✅ Theme preference persists in localStorage across page navigation
- ✅ Added dark mode styles to Ideas, Experiments, and Reflection pages
- ✅ Fixed text visibility issues in dark mode
- ✅ Ensured consistent UI in both light and dark themes

## Testing
- Toggle dark mode on home page - persists across all pages
- Navigate between Ideas, Experiments, Reflection - theme remains consistent
- Refresh page - theme preference is maintained
- All text is clearly visible in both modes

Fixes the issue where dark mode toggle was only on home page and didn't persist across navigation.