### PR TITLE
feat: add reflection creation page and integrate outcomes flow

### DIFF
--- a/frontend/app/experiments/page.tsx
+++ b/frontend/app/experiments/page.tsx
@@ -2,7 +2,6 @@
 
 import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
-import Link from "next/link";
 import { apiFetch } from "../lib/api";
 import { PageLayout } from "../community/PageLayout";
 import LoadingState from "../components/LoadingState";
@@ -99,7 +98,6 @@ export default function ExperimentsPage() {
     fetchExperiments();
   }, []);
 
-  // Status color
   const getStatusTextColor = (status: string) => {
     if (status === "completed") return "text-green-600 dark:text-green-400";
     if (status === "in-progress") return "text-blue-600 dark:text-blue-400";
@@ -138,7 +136,9 @@ export default function ExperimentsPage() {
             <BackButton />
           </div>
 
-          <div className="flex items-center justify-between mb-3">
+          <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4 mb-3">
+
+            {/* LEFT SIDE */}
             <div className="flex items-center gap-3">
               <ChartHistogramIcon className="w-8 h-8 text-blue-600 dark:text-blue-400" />
               <h1 className="text-4xl font-bold text-black dark:text-white">
@@ -146,9 +146,22 @@ export default function ExperimentsPage() {
               </h1>
             </div>
 
-            <Button onClick={() => router.push("/experiments/new")}>
-              + New Experiment
-            </Button>
+            {/* RIGHT SIDE BUTTON GROUP */}
+            <div className="flex items-center gap-4">
+              <Button
+                onClick={() => router.push("/outcomes")}
+                className="rounded-full px-6 py-2"
+              >
+                View Outcomes
+              </Button>
+
+              <Button
+                onClick={() => router.push("/experiments/new")}
+                className="rounded-full px-6 py-2"
+              >
+                + New Experiment
+              </Button>
+            </div>
           </div>
 
           <p className="text-lg max-w-2xl text-black dark:text-white">
@@ -173,14 +186,16 @@ export default function ExperimentsPage() {
                   Start your first experiment to test and validate ideas.
                 </p>
 
-                <Button onClick={() => router.push("/experiments/new")}>
+                <Button
+                  onClick={() => router.push("/experiments/new")}
+                  className="rounded-full px-6 py-2"
+                >
                   + Create First Experiment
                 </Button>
               </div>
             </MagicCard>
           </div>
         ) : (
-          /* Experiments Grid */
           <div className="grid gap-6 md:grid-cols-2">
             {experiments.map((exp) => (
               <div key={exp.id} className="card">
@@ -194,9 +209,7 @@ export default function ExperimentsPage() {
 
                 <div className="flex justify-between items-center mb-2">
                   <span
-                    className={`text-sm font-medium ${getStatusTextColor(
-                      exp.status
-                    )}`}
+                    className={`text-sm font-medium ${getStatusTextColor(exp.status)}`}
                   >
                     Status: {exp.statusLabel}
                   </span>
@@ -208,9 +221,7 @@ export default function ExperimentsPage() {
 
                 <div className="w-full bg-gray-200 dark:bg-slate-700 rounded-full h-2">
                   <div
-                    className={`h-2 rounded-full ${getProgressColor(
-                      exp.status
-                    )}`}
+                    className={`h-2 rounded-full ${getProgressColor(exp.status)}`}
                     style={{ width: `${exp.progress}%` }}
                   />
                 </div>

--- a/frontend/app/outcomes/page.tsx
+++ b/frontend/app/outcomes/page.tsx
@@ -2,11 +2,14 @@
 
 import { useEffect, useState } from "react";
 import { TrendingUp, FileText } from "lucide-react";
+import { useRouter } from "next/navigation";
 import { PageLayout } from "../community/PageLayout";
 import { apiFetch } from "../lib/api";
 import LoadingState from "../components/LoadingState";
 import ErrorState from "../components/ErrorState";
 import BackButton from "../components/BackButton";
+import Button from "@/app/components/ui/Button";
+import { MagicCard } from "@/components/ui/magic-card";
 
 interface Outcome {
   id: number;
@@ -17,9 +20,12 @@ interface Outcome {
 }
 
 const outcomeColors: Record<string, string> = {
-  Success: "text-green-600 dark:text-green-400 bg-green-100 dark:bg-green-900/30",
-  Mixed: "text-yellow-600 dark:text-yellow-400 bg-yellow-100 dark:bg-yellow-900/30",
-  Failed: "text-red-600 dark:text-red-400 bg-red-100 dark:bg-red-900/30",
+  Success:
+    "text-green-600 dark:text-green-400 bg-green-100 dark:bg-green-900/30",
+  Mixed:
+    "text-yellow-600 dark:text-yellow-400 bg-yellow-100 dark:bg-yellow-900/30",
+  Failed:
+    "text-red-600 dark:text-red-400 bg-red-100 dark:bg-red-900/30",
 };
 
 const formatDate = (dateString?: string): string => {
@@ -39,6 +45,8 @@ export default function OutcomesPage() {
   const [outcomes, setOutcomes] = useState<Outcome[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+
+  const router = useRouter();
 
   useEffect(() => {
     const fetchOutcomes = async () => {
@@ -89,19 +97,39 @@ export default function OutcomesPage() {
         </div>
 
         <p className="text-lg text-gray-600 dark:text-gray-300 mb-10">
-          Outcomes are the results of your experiments. Track what works, what doesn't, and learn from each result.
+          Outcomes are the results of your experiments. Track what works,
+          what doesn't, and reflect on each result.
         </p>
 
         {outcomes.length === 0 ? (
-          <div className="card text-center py-12">
-            <h2 className="text-2xl font-semibold text-gray-800 dark:text-white mb-3">
-              No outcomes yet
-            </h2>
-            <p className="text-gray-500 dark:text-gray-400 mb-6">
-              Run experiments to see outcomes here.
-            </p>
-          </div>
-        ) : (
+  <div className="mt-10">
+    <MagicCard
+      className="p-[1px] rounded-2xl w-full"
+      gradientColor="rgba(59,130,246,0.6)"
+    >
+      <div className="bg-white/10 dark:bg-slate-900/40 backdrop-blur-xl rounded-2xl border border-white/10 px-10 py-16 text-center">
+        <TrendingUp className="w-12 h-12 mx-auto mb-6 text-blue-400 opacity-80" />
+
+        <h3 className="text-2xl font-semibold text-black dark:text-white mb-3">
+          No outcomes yet
+        </h3>
+
+        <p className="text-slate-400 text-sm leading-relaxed mb-8 max-w-xl mx-auto">
+          Run experiments to generate outcomes and start reflecting on results.
+        </p>
+
+        <Button
+          onClick={() => router.push("/experiments")}
+          className="rounded-full px-8 py-3"
+        >
+          View Experiments
+        </Button>
+      </div>
+    </MagicCard>
+  </div>
+) : (
+
+
           <div className="space-y-6">
             {outcomes.map((outcome) => (
               <div
@@ -117,9 +145,11 @@ export default function OutcomesPage() {
                       Outcome #{outcome.id}
                     </span>
                   </div>
+
                   <span
                     className={`text-xs font-medium px-3 py-1 rounded-full ${
-                      outcomeColors[outcome.result] || "bg-gray-100 dark:bg-gray-700"
+                      outcomeColors[outcome.result] ||
+                      "bg-gray-100 dark:bg-gray-700"
                     }`}
                   >
                     {outcome.result}
@@ -127,7 +157,7 @@ export default function OutcomesPage() {
                 </div>
 
                 {outcome.notes && (
-                  <div className="bg-blue-50 dark:bg-blue-900/20 border-l-4 border-blue-500 rounded-r-lg p-4">
+                  <div className="bg-blue-50 dark:bg-blue-900/20 border-l-4 border-blue-500 rounded-r-lg p-4 mb-4">
                     <div className="flex items-start gap-2">
                       <FileText className="w-4 h-4 text-blue-600 mt-0.5 shrink-0" />
                       <p className="text-sm text-gray-700 dark:text-gray-300">
@@ -137,8 +167,21 @@ export default function OutcomesPage() {
                   </div>
                 )}
 
-                <div className="mt-3 text-xs text-gray-500">
-                  {formatDate(outcome.createdAt)}
+                <div className="flex items-center justify-between mt-4">
+                  <span className="text-xs text-gray-500">
+                    {formatDate(outcome.createdAt)}
+                  </span>
+
+                  <Button
+                    onClick={() =>
+                      router.push(
+                        `/reflection/new?outcomeId=${outcome.id}`
+                      )
+                    }
+                    className="rounded-full px-4 py-2 text-sm"
+                  >
+                    + Add Reflection
+                  </Button>
                 </div>
               </div>
             ))}

--- a/frontend/app/reflection/new/page.tsx
+++ b/frontend/app/reflection/new/page.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { apiFetch } from "../../lib/api";
+import { PageLayout } from "../../community/PageLayout";
+import Button from "@/app/components/ui/Button";
+import { MagicCard } from "@/components/ui/magic-card";
+
+interface Outcome {
+  id: number;
+  result: string;
+}
+
+const CONTENT_LIMIT = 1000;
+
+export default function NewReflectionPage() {
+  const router = useRouter();
+
+  const [outcomes, setOutcomes] = useState<Outcome[]>([]);
+  const [selectedOutcome, setSelectedOutcome] = useState<number | null>(null);
+  const [content, setContent] = useState("");
+
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Fetch outcomes
+  useEffect(() => {
+    const fetchOutcomes = async () => {
+      try {
+        const data = await apiFetch<Outcome[]>("/outcomes");
+        setOutcomes(data);
+      } catch {
+        setError("Failed to load outcomes");
+      }
+    };
+
+    fetchOutcomes();
+  }, []);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (!selectedOutcome || !content.trim()) {
+      setError("Outcome and reflection content are required");
+      return;
+    }
+
+    try {
+      setLoading(true);
+      setError(null);
+
+      await apiFetch("/reflection", {
+        method: "POST",
+        body: JSON.stringify({
+          outcomeId: selectedOutcome,
+          content,
+        }),
+      });
+
+      router.push("/reflection");
+    } catch (err: any) {
+      setError(err.message || "Failed to create reflection");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <PageLayout>
+      <div className="section max-w-2xl mx-auto">
+
+        {/* Back Button */}
+        <div className="mb-6">
+          <Button
+            onClick={() => router.push("/reflection")}
+            className="rounded-full px-6 py-2"
+          >
+            ← Back to Reflections
+          </Button>
+        </div>
+
+        <h1 className="text-3xl font-bold mb-2 text-black dark:text-white">
+          Create New Reflection
+        </h1>
+
+        <p className="text-gray-600 dark:text-gray-400 mb-6">
+          Reflect on what you learned from an outcome.
+        </p>
+
+        <MagicCard
+          gradientColor="rgba(59,130,246,0.6)"
+          className="p-8 rounded-3xl bg-white/75 dark:bg-zinc-900/70 backdrop-blur-xl border border-white/10 shadow-xl"
+        >
+          <form onSubmit={handleSubmit} className="space-y-6">
+
+            {error && (
+              <div className="text-red-500 text-sm">
+                {error}
+              </div>
+            )}
+
+            {/* Outcome Select */}
+            <div>
+              <label className="block text-sm font-medium mb-2">
+                Select Outcome
+              </label>
+
+              <select
+                className="w-full p-3 rounded-xl border border-gray-300 dark:border-zinc-700 bg-white dark:bg-zinc-950"
+                value={selectedOutcome ?? ""}
+                onChange={(e) =>
+                  setSelectedOutcome(Number(e.target.value))
+                }
+              >
+                <option value="">Choose outcome</option>
+                {outcomes.map((o) => (
+                  <option key={o.id} value={o.id}>
+                    {o.result}
+                  </option>
+                ))}
+              </select>
+
+              {/* Show message if no outcomes */}
+              {outcomes.length === 0 && (
+                <p className="text-sm text-red-500 mt-2">
+                  No outcomes available. Create an outcome first.
+                </p>
+              )}
+            </div>
+
+            {/* Reflection Content */}
+            <div>
+              <label className="block text-sm font-medium mb-2">
+                Reflection
+              </label>
+
+              <textarea
+                rows={6}
+                maxLength={CONTENT_LIMIT}
+                className="w-full p-3 rounded-xl border border-gray-300 dark:border-zinc-700 bg-white dark:bg-zinc-950"
+                placeholder="What did you learn? What would you improve?"
+                value={content}
+                onChange={(e) => setContent(e.target.value)}
+              />
+
+              <div className="text-xs text-right mt-1 text-gray-500">
+                {content.length}/{CONTENT_LIMIT}
+              </div>
+            </div>
+
+            <Button
+              type="submit"
+              disabled={loading || outcomes.length === 0}
+              className="w-full rounded-full py-3"
+            >
+              {loading ? "Creating..." : "+ Create Reflection"}
+            </Button>
+
+          </form>
+        </MagicCard>
+      </div>
+    </PageLayout>
+  );
+}

--- a/frontend/app/reflection/page.tsx
+++ b/frontend/app/reflection/page.tsx
@@ -143,7 +143,7 @@ export default function ReflectionPage() {
               </h1>
             </div>
 
-            <Button onClick={() => router.push("/reflections/new")}>
+            <Button onClick={() => router.push("/reflection/new")}>
               + New Reflection
             </Button>
           </div>
@@ -171,7 +171,7 @@ export default function ReflectionPage() {
                   Start recording learnings from your outcomes.
                 </p>
 
-                <Button onClick={() => router.push("/reflections/new")}>
+                <Button onClick={() => router.push("/reflection/new")}>
                   + Add First Reflection
                 </Button>
               </div>


### PR DESCRIPTION
- Created new reflection creation page
- Revamped outcomes page UI with MagicCard styling
- Added navigation from experiments to outcomes
- Integrated reflection flow from outcomes page
- Improved layout consistency across pages
<img width="1450" height="810" alt="Screenshot 2026-02-19 at 8 27 04 PM" src="https://github.com/user-attachments/assets/8c19b5d6-05de-4566-a771-d34c5c32c033" />
<img width="1463" height="810" alt="Screenshot 2026-02-19 at 8 27 20 PM" src="https://github.com/user-attachments/assets/14de9692-c6a7-4996-a9df-65a262f73639" />
<img width="1464" height="805" alt="Screenshot 2026-02-19 at 8 27 39 PM" src="https://github.com/user-attachments/assets/37bc7878-a645-4d74-8600-79b15324a19d" />
