### PR TITLE
Add experiment delete with confirmation modal

### DIFF
--- a/frontend/app/lib/api.ts
+++ b/frontend/app/lib/api.ts
@@ -43,11 +43,15 @@ export async function apiFetch<T>(endpoint: string, init?: RequestInit): Promise
       data.outcomes;
 
 
-    if (!result) {
-      throw new Error("No data returned");
-    }
+    // allow empty response for DELETE
+if (result === undefined) {
+  if (init?.method === "DELETE") {
+    return undefined as T;
+  }
+  throw new Error("No data returned");
+}
 
-    return result;
+return result as T;
 
   } catch (error: any) {
 


### PR DESCRIPTION
- Added delete option to experiment cards
- Implemented confirmation modal before deletion
- Fixed apiFetch to allow DELETE responses without data
- Ensured UI updates without page reload
<img width="1458" height="801" alt="Screenshot 2026-02-20 at 11 38 00 PM" src="https://github.com/user-attachments/assets/d862b37d-fdcc-4088-b525-49108409943e" />
<img width="1459" height="810" alt="Screenshot 2026-02-20 at 11 38 12 PM" src="https://github.com/user-attachments/assets/c4e48594-95e1-4346-b2b1-39bd0b02e509" />
<img width="1458" height="805" alt="Screenshot 2026-02-20 at 11 38 23 PM" src="https://github.com/user-attachments/assets/29f263f9-b5a7-4517-a194-c5fad71cc957" />
