### PR TITLE
Complete outcome and reflection flow

### DIFF
--- a/backend/src/routes/outcomes.routes.ts
+++ b/backend/src/routes/outcomes.routes.ts
@@ -3,7 +3,8 @@ import { Router, Request, Response } from "express";
 import {
   createOutcome,
   getAllOutcomes,
-  getOutcomesByExperimentId
+  getOutcomesByExperimentId,
+  updateOutcomeResult
 } from "../services/outcomes.service";
 
 const router = Router();
@@ -86,5 +87,37 @@ router.get("/:experimentId", (req: Request, res: Response) => {
     });
   }
 });
+router.put("/:id", (req: Request, res: Response) => {
+  try {
+    const id = Number(req.params.id);
+    const { result } = req.body;
 
+    if (!id || !result) {
+      return res.status(400).json({
+        success: false,
+        message: "id and result are required",
+      });
+    }
+
+    const updated = updateOutcomeResult(id, result);
+
+    if (!updated) {
+      return res.status(404).json({
+        success: false,
+        message: "Outcome not found",
+      });
+    }
+
+    return res.json({
+      success: true,
+      data: updated,
+    });
+
+  } catch {
+    return res.status(500).json({
+      success: false,
+      message: "Failed to update outcome",
+    });
+  }
+});
 export default router;

--- a/backend/src/services/experiments.service.ts
+++ b/backend/src/services/experiments.service.ts
@@ -12,7 +12,7 @@ export interface Experiment {
   title: string;
   description: string;
   status: ExperimentStatus;
-  outcome?: string;
+  outcomeResult?: "Success" | "Failed" | null;
   createdAt: Date;
 }
 
@@ -88,8 +88,8 @@ export const updateExperiment = (
   if (updates.status !== undefined)
     experiment.status = updates.status;
 
-  if (updates.outcome !== undefined)
-    experiment.outcome = updates.outcome;
+  if (updates.outcomeResult !== undefined)
+  experiment.outcomeResult = updates.outcomeResult;
 
   return experiment;
 };

--- a/backend/src/services/outcomes.service.ts
+++ b/backend/src/services/outcomes.service.ts
@@ -1,4 +1,5 @@
 // backend/src/services/outcomes.service.ts
+import { getExperimentById } from "./experiments.service";
 
 export interface Outcome {
   id: number;
@@ -36,10 +37,16 @@ export const createOutcome = (
 
 
 // Get all outcomes
-export const getAllOutcomes = (): Outcome[] => {
-  return outcomes;
-};
+export const getAllOutcomes = () => {
+  return outcomes.map((o) => {
+    const experiment = getExperimentById(o.experimentId);
 
+    return {
+      ...o,
+      experimentTitle: experiment?.title || "Unknown Experiment",
+    };
+  });
+};
 
 // Get outcomes by experiment ID
 export const getOutcomesByExperimentId = (
@@ -50,4 +57,18 @@ export const getOutcomesByExperimentId = (
     outcome => outcome.experimentId === experimentId
   );
 
+};
+
+// Update outcome result
+export const updateOutcomeResult = (
+  id: number,
+  result: string
+): Outcome | null => {
+
+  const outcome = outcomes.find(o => o.id === id);
+
+  if (!outcome) return null;
+
+  outcome.result = result;
+  return outcome;
 };

--- a/frontend/app/components/ExperimentForm.tsx
+++ b/frontend/app/components/ExperimentForm.tsx
@@ -69,7 +69,7 @@ export function ExperimentForm() {
       body: JSON.stringify({
         title: formData.title,
         description: formData.hypothesis,
-        status: "planned", // required by backend
+        status: "in-progress",
       }),
     });
 

--- a/frontend/app/experiments/[id]/page.tsx
+++ b/frontend/app/experiments/[id]/page.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useParams, useRouter } from "next/navigation";
+import { apiFetch } from "@/app/lib/api";
+import { PageLayout } from "@/app/community/PageLayout";
+import LoadingState from "@/app/components/LoadingState";
+import ErrorState from "@/app/components/ErrorState";
+import Button from "@/app/components/ui/Button";
+import { MagicCard } from "@/components/ui/magic-card";
+interface Experiment {
+  id: number;
+  title: string;
+  description: string;
+  status: "planned" | "in-progress" | "completed";
+  progress: number;
+}
+
+export default function ExperimentDetailPage() {
+  const { id } = useParams();
+  const router = useRouter();
+
+  const [experiment, setExperiment] = useState<Experiment | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchExperiment = async () => {
+      try {
+        setLoading(true);
+        const data = await apiFetch<Experiment>(`/experiments/${id}`);
+        setExperiment(data);
+      } catch (err: any) {
+        setError(err.message || "Failed to load experiment");
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    if (id) fetchExperiment();
+  }, [id]);
+
+  const updateStatus = async (status: "completed" | "in-progress") => {
+  if (!experiment) return;
+
+  try {
+    const updated = await apiFetch<Experiment>(`/experiments/${experiment.id}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ status }),
+    });
+
+    setExperiment(updated);
+
+    // If completed → redirect to create outcome
+    if (status === "completed") {
+      router.push(`/outcomes/new?experimentId=${experiment.id}`);
+    }
+
+  } catch (err: any) {
+    alert(err.message || "Failed to update status");
+  }
+};
+
+  if (loading) {
+    return (
+      <PageLayout>
+        <LoadingState message="Loading experiment..." />
+      </PageLayout>
+    );
+  }
+
+  if (error || !experiment) {
+    return (
+      <PageLayout>
+        <ErrorState message={error || "Experiment not found"} />
+      </PageLayout>
+    );
+  }
+
+  return (
+  <PageLayout>
+    <div className="flex justify-center py-16">
+      <MagicCard
+        className="p-[1px] rounded-2xl w-full max-w-3xl"
+        gradientColor="rgba(59,130,246,0.6)"
+      >
+        <div className="bg-white/10 dark:bg-slate-900/50 backdrop-blur-xl rounded-2xl p-10 border border-white/10 space-y-8">
+
+          <Button onClick={() => router.push("/experiments")}>
+            ← Back to Experiments
+          </Button>
+
+          <div>
+            <h1 className="text-3xl font-bold mb-3">
+              {experiment.title}
+            </h1>
+
+            <p className="text-gray-600 dark:text-gray-300">
+              {experiment.description}
+            </p>
+          </div>
+
+          <div className="space-y-4">
+            <div className="text-lg font-medium">
+              Status:{" "}
+              <span
+                className={
+                  experiment.status === "completed"
+                    ? "text-green-500"
+                    : "text-blue-400"
+                }
+              >
+                {experiment.status}
+              </span>
+            </div>
+
+            <div className="flex gap-4">
+              <Button
+                onClick={() => updateStatus("in-progress")}
+              >
+                Mark In Progress
+              </Button>
+
+              <Button
+                onClick={() => updateStatus("completed")}
+              >
+                Mark Completed
+              </Button>
+            </div>
+          </div>
+
+        </div>
+      </MagicCard>
+    </div>
+  </PageLayout>
+);
+}

--- a/frontend/app/experiments/page.tsx
+++ b/frontend/app/experiments/page.tsx
@@ -90,7 +90,10 @@ export default function ExperimentsPage() {
         setError(null);
 
         const data = await apiFetch<BackendExperiment[]>("/experiments");
-        setExperiments(data.map(normalizeExperiment));
+        const normalized = data.map(normalizeExperiment);
+        setExperiments(
+          normalized.filter(exp => exp.status !== "completed")
+        );
       } catch (err: any) {
         setError(err.message || "Failed to fetch experiments");
       } finally {
@@ -223,8 +226,12 @@ export default function ExperimentsPage() {
         ) : (
           <div className="grid gap-6 md:grid-cols-2">
             {experiments.map((exp) => (
+  <div
+  key={exp.id}
+  onClick={() => router.push(`/experiments/${exp.id}`)}
+  className="cursor-pointer hover:scale-[1.02] transition"
+>
   <MagicCard
-    key={exp.id}
     className="p-[1px] rounded-xl relative"
     gradientColor="rgba(59,130,246,0.6)"
   >
@@ -232,7 +239,10 @@ export default function ExperimentsPage() {
 
       {/* Delete Button */}
       <button
-        onClick={() => setDeleteExperiment(exp)}
+  onClick={(e) => {
+    e.stopPropagation();
+    setDeleteExperiment(exp);
+  }}
         className="absolute top-4 right-4 p-2 text-red-400 hover:text-red-600 transition"
       >
         <TrashIcon className="w-5 h-5" />
@@ -267,6 +277,7 @@ export default function ExperimentsPage() {
 
     </div>
   </MagicCard>
+  </div>
 ))}
           </div>
         )}

--- a/frontend/app/outcomes/new/page.tsx
+++ b/frontend/app/outcomes/new/page.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { useSearchParams, useRouter } from "next/navigation";
+import { useState } from "react";
+import { PageLayout } from "@/app/community/PageLayout";
+import Button from "@/app/components/ui/Button";
+import { MagicCard } from "@/components/ui/magic-card";
+import { apiFetch } from "@/app/lib/api";
+
+export default function NewOutcomePage() {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+
+  const experimentId = searchParams.get("experimentId");
+
+  const [result, setResult] = useState("Success");
+  const [notes, setNotes] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleSubmit = async () => {
+    if (!experimentId) return;
+
+    try {
+      setIsSubmitting(true);
+
+      await apiFetch("/outcomes", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          experimentId: Number(experimentId),
+          result,
+          notes,
+        }),
+      });
+
+      router.push("/outcomes");
+    } catch (err: any) {
+      alert(err.message || "Failed to create outcome");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <PageLayout>
+      <div className="flex justify-center py-16">
+        <MagicCard
+          className="p-[1px] rounded-2xl w-full max-w-2xl"
+          gradientColor="rgba(59,130,246,0.6)"
+        >
+          <div className="bg-white/10 dark:bg-slate-900/50 backdrop-blur-xl rounded-2xl p-10 border border-white/10 space-y-8">
+
+            <h1 className="text-2xl font-bold">
+              Create Outcome
+            </h1>
+
+            <div>
+              <label className="block mb-2 font-medium">
+                Result
+              </label>
+
+              <select
+                value={result}
+                onChange={(e) => setResult(e.target.value)}
+                className="w-full px-4 py-2 rounded-lg border bg-background"
+              >
+                <option>Success</option>
+                <option>Mixed</option>
+                <option>Failed</option>
+              </select>
+            </div>
+
+            <div>
+              <label className="block mb-2 font-medium">
+                Notes (optional)
+              </label>
+
+              <textarea
+                value={notes}
+                onChange={(e) => setNotes(e.target.value)}
+                rows={4}
+                className="w-full px-4 py-3 rounded-lg border bg-background"
+              />
+            </div>
+
+            <div className="flex gap-4">
+              <Button onClick={() => router.back()}>
+                Cancel
+              </Button>
+
+              <Button onClick={handleSubmit} disabled={isSubmitting}>
+                {isSubmitting ? "Creating..." : "Create Outcome"}
+              </Button>
+            </div>
+
+          </div>
+        </MagicCard>
+      </div>
+    </PageLayout>
+  );
+}

--- a/frontend/app/reflection/new/page.tsx
+++ b/frontend/app/reflection/new/page.tsx
@@ -9,6 +9,8 @@ import { MagicCard } from "@/components/ui/magic-card";
 
 interface Outcome {
   id: number;
+  experimentId: number;
+  experimentTitle: string;
   result: string;
 }
 
@@ -50,14 +52,16 @@ export default function NewReflectionPage() {
       setLoading(true);
       setError(null);
 
-      await apiFetch("/reflection", {
-        method: "POST",
-        body: JSON.stringify({
-          outcomeId: selectedOutcome,
-          content,
-        }),
-      });
-
+      await apiFetch("/reflections", {
+  method: "POST",
+  headers: {
+    "Content-Type": "application/json",
+  },
+  body: JSON.stringify({
+    outcomeId: selectedOutcome,
+    content,
+  }),
+});
       router.push("/reflection");
     } catch (err: any) {
       setError(err.message || "Failed to create reflection");
@@ -116,8 +120,8 @@ export default function NewReflectionPage() {
                 <option value="">Choose outcome</option>
                 {outcomes.map((o) => (
                   <option key={o.id} value={o.id}>
-                    {o.result}
-                  </option>
+  {o.experimentTitle}
+</option>
                 ))}
               </select>
 

--- a/frontend/app/reflection/page.tsx
+++ b/frontend/app/reflection/page.tsx
@@ -31,6 +31,8 @@ interface ReflectionApiResponse {
 
 interface OutcomeApiResponse {
   id: number;
+  experimentId: number;
+  experimentTitle: string;
   result: string;
 }
 


### PR DESCRIPTION
This PR implements the full experiment lifecycle from completion to reflection.
When an experiment is marked as completed, it appears in the Outcomes page
Users can mark an outcome as Success or Failed
Reflections are linked to outcomes
Reflection dropdown displays experiment name instead of status
Backend updated to include experimentTitle in outcomes response
Added PUT endpoint for updating outcome result
<img width="1457" height="805" alt="Screenshot 2026-02-21 at 1 06 38 AM" src="https://github.com/user-attachments/assets/0300f6e0-5922-415d-806f-c7bdcd52601e" />
<img width="1408" height="710" alt="Scre
<img width="1454" height="805" alt="Screenshot 2026-02-21 at 1 07 19 AM" src="https://github.com/user-attachments/assets/b4050854-fdaa-4b1e-831b-5130c2a377a7" />
enshot 2026-02-21 at 1 07 05 AM" src="https://github.com/user-attachments/assets/4ab6b34b-f595-4880-9f3f-4e6bfd161e06" />
<img width="1457" height="805" alt="Screenshot 2026-02-21 at 1 07 43 AM" src="https://github.c
<img width="1458" height="817" alt="Screenshot 2026-02-21 at 1 08 04 AM" src="https://github.com/user-attachments/assets/dd467532-792e-45ca-8bb5-f798fc38c4ad" />
om/user-attachments/assets/b5ed29bd-5e5d-4d97-b245-715d1b5d8372" />
<img width="1449" height="806" alt="Screenshot 2026-02-21 at 1 08 22 AM" src="https://github.com/user-attachments/assets/e9b26e0d-0f11-4d7e-966f-0c7396abb62b" />
