### PR TITLE
Enforce Data Integrity: Prevent Deletion of Experiments with Recorded Outcomes

### DIFF
--- a/backend/src/controllers/experiments.controller.ts
+++ b/backend/src/controllers/experiments.controller.ts
@@ -164,6 +164,7 @@ export const removeExperiment = (
     }
 
     const deleted = deleteExperiment(id);
+
     if (!deleted) {
       res.status(404).json({
         success: false,
@@ -176,7 +177,11 @@ export const removeExperiment = (
       success: true,
       message: "Experiment deleted",
     });
-  } catch (error) {
-    next(error);
+
+  } catch (err: any) {
+    res.status(400).json({
+      success: false,
+      message: err.message,
+    });
   }
 };

--- a/backend/src/services/experiments.service.ts
+++ b/backend/src/services/experiments.service.ts
@@ -1,5 +1,5 @@
 // backend/src/services/experiments.service.ts
-
+import { hasOutcomeForExperiment } from "./outcomes.service";
 export type ExperimentStatus = "planned" | "in-progress" | "completed";
 export const EXPERIMENT_PROGRESS_BY_STATUS: Record<ExperimentStatus, number> = {
   planned: 0,
@@ -103,14 +103,16 @@ export const updateExperiment = (
 };
 
 
-// Delete experiment
 export const deleteExperiment = (id: number): boolean => {
 
   const index = experiments.findIndex(e => e.id === id);
-
   if (index === -1) return false;
 
-  experiments.splice(index, 1);
+  // 🔒 Prevent deletion if outcome exists
+  if (hasOutcomeForExperiment(id)) {
+    throw new Error("Cannot delete experiment with a recorded outcome.");
+  }
 
+  experiments.splice(index, 1);
   return true;
 };

--- a/backend/src/services/outcomes.service.ts
+++ b/backend/src/services/outcomes.service.ts
@@ -72,3 +72,7 @@ export const updateOutcomeResult = (
   outcome.result = result;
   return outcome;
 };
+
+export const hasOutcomeForExperiment = (experimentId: number): boolean => {
+  return outcomes.some(o => o.experimentId === experimentId);
+};

--- a/frontend/app/experiments/page.tsx
+++ b/frontend/app/experiments/page.tsx
@@ -82,7 +82,7 @@ export default function ExperimentsPage() {
   const [deleteExperiment, setDeleteExperiment] = useState<Experiment | null>(null);
   const [deleting, setDeleting] = useState(false);
   const router = useRouter();
-
+  const [deleteError, setDeleteError] = useState<string | null>(null);
   useEffect(() => {
     const fetchExperiments = async () => {
       try {
@@ -118,8 +118,8 @@ export default function ExperimentsPage() {
 
     setDeleteExperiment(null);
   } catch (err: any) {
-    alert(err.message || "Failed to delete experiment");
-  } finally {
+  setDeleteError(err.message || "Failed to delete experiment");
+} finally {
     setDeleting(false);
   }
 };
@@ -316,6 +316,38 @@ export default function ExperimentsPage() {
               {deleting ? "Deleting..." : "Delete"}
             </Button>
           </div>
+
+        </div>
+      </MagicCard>
+    </div>
+  </div>
+)}
+{deleteError && (
+  <div
+    className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm"
+    onClick={() => setDeleteError(null)}
+  >
+    <div onClick={(e) => e.stopPropagation()}>
+      <MagicCard
+        className="p-[1px] rounded-2xl"
+        gradientColor="rgba(239,68,68,0.6)"
+      >
+        <div className="bg-white/10 dark:bg-slate-900/50 backdrop-blur-xl rounded-2xl px-7 py-7 w-[380px]">
+
+          <h2 className="text-xl font-bold text-blue-100 mb-3">
+            Cannot Delete Experiment
+          </h2>
+
+          <p className="text-slate-200 text-sm leading-relaxed mb-6">
+            {deleteError}
+          </p>
+
+          <Button
+            className="w-full"
+            onClick={() => setDeleteError(null)}
+          >
+            Okay
+          </Button>
 
         </div>
       </MagicCard>


### PR DESCRIPTION
## Summary

This update enforces data integrity by preventing the deletion of experiments that have associated outcomes. It ensures the structured learning chain remains consistent and avoids orphaned outcome records.

## Changes

* Added guard in the experiments service to block deletion if an outcome exists for the experiment
* Introduced a helper function in the outcomes service to check experiment linkage
* Updated the experiments controller to return a proper error response instead of a server crash
* Replaced the browser default alert with a styled frontend modal for consistent UI feedback
* Eliminated the “Unknown Experiment” state in the outcomes page

## Result

EchoRoom now preserves learning history integrity across:

Idea → Experiment → Outcome → Reflection

Experiments with recorded outcomes are protected from accidental deletion, reinforcing the platform’s structured workflow and domain consistency.

---
<img width="1455" height="815" alt="Screenshot 2026-02-23 at 1 39 57 PM" src="https://github.com/user-attachments/assets/ae5d1fcf-fbf4-48bb-aaf1-418c02f2cacb" />
<img width="794" height="581" alt="Screenshot 2026-02-23 at 1 40 13 PM" src="https://github.com/user-attachments/assets/65066eee-16f3-4182-893b-ca9603594485" />
