### PR TITLE
backend: split express app into shared app entrypoint

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -1,0 +1,36 @@
+import express, { Request, Response } from "express";
+import cors from "cors";
+import "dotenv/config";
+
+import ideasRoutes from "./routes/ideas.routes";
+import experimentsRoutes from "./routes/experiments.routes";
+import outcomesRoutes from "./routes/outcomes.routes";
+import reflectionsRoutes from "./routes/reflections.routes";
+import authRoutes from "./routes/auth.routes";
+import commentsRoutes from "./routes/comments.routes";
+import { errorMiddleware, notFoundMiddleware } from "./middleware/error.middleware";
+import likesRoutes from "./routes/likes.routes";
+import insightsRoutes from "./routes/insights.routes";
+
+const app = express();
+
+app.use(cors({ origin: ["http://localhost:3000", "http://localhost:3001"] }));
+app.use(express.json());
+
+app.get("/health", (_req: Request, res: Response) => {
+  res.json({ success: true, message: "Backend is running" });
+});
+
+app.use("/auth", authRoutes);
+app.use("/ideas", ideasRoutes);
+app.use("/experiments", experimentsRoutes);
+app.use("/outcomes", outcomesRoutes);
+app.use("/reflections", reflectionsRoutes);
+app.use("/insights", insightsRoutes);
+app.use("/ideas/:ideaId/comments", commentsRoutes);
+app.use("/likes", likesRoutes);
+
+app.use(notFoundMiddleware);
+app.use(errorMiddleware);
+
+export default app;

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,41 +1,4 @@
-// backend/src/index.ts
-import express, { Request, Response } from "express";
-import cors from "cors";
-import "dotenv/config";
-
-import ideasRoutes from "./routes/ideas.routes";
-import experimentsRoutes from "./routes/experiments.routes";
-import outcomesRoutes from "./routes/outcomes.routes";
-import reflectionsRoutes from "./routes/reflections.routes";
-import authRoutes from "./routes/auth.routes";
-import commentsRoutes from "./routes/comments.routes";
-import { errorMiddleware, notFoundMiddleware } from "./middleware/error.middleware";
-import likesRoutes from "./routes/likes.routes";
-import insightsRoutes from "./routes/insights.routes";
-
-// import prisma from "./lib/prisma";
-console.log("INDEX TS SERVER STARTED");
-
-const app = express();
-
-app.use(cors({ origin: ["http://localhost:3000", "http://localhost:3001"] }));
-app.use(express.json());
-
-app.get("/health", (_req: Request, res: Response) => {
-  res.json({ success: true, message: "Backend is running" });
-});
-
-app.use("/auth", authRoutes);
-app.use("/ideas", ideasRoutes);
-app.use("/experiments", experimentsRoutes);
-app.use("/outcomes", outcomesRoutes);
-app.use("/reflections", reflectionsRoutes);
-app.use("/insights", insightsRoutes);
-app.use("/ideas/:ideaId/comments", commentsRoutes);
-app.use("/likes", likesRoutes);
-
-app.use(notFoundMiddleware);
-app.use(errorMiddleware);
+import app from "./app";
 
 const PORT = process.env.PORT || 5000;
 

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -1,1 +1,7 @@
-import "./index";
+import app from "./app";
+
+const PORT = process.env.PORT || 5000;
+
+app.listen(PORT, () => {
+  console.log(`Server running on http://localhost:${PORT}`);
+});


### PR DESCRIPTION
  ## Summary                                                                                          
  - add `backend/src/app.ts` as the shared Express app module                                         
  - update `backend/src/index.ts` to only start the server from the shared app                        
  - update `backend/src/server.ts` to start from the same shared app                                  
                                                                                                      
  ## Why                                                                                              
  `server.ts` should not depend on a missing/implicit app module pattern. This ensures both dev/prod  
  entrypoints use one canonical Express app definition and avoids entrypoint import drift.            
   