### PR TITLE
backend: remove duplicate server bootstrap entrypoint

### DIFF
--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -1,7 +1,0 @@
-import app from "./app";
-
-const PORT = process.env.PORT || 5000;
-
-app.listen(PORT, () => {
-  console.log(`Server running on http://localhost:${PORT}`);
-});


### PR DESCRIPTION
## Summary                                                                                          
  This PR removes duplicate backend startup bootstrapping by deleting `backend/src/server.ts` and     
  keeping `backend/src/index.ts` as the single canonical entrypoint.                                  
                                                                                                      
  ## Why                                                                                              
  Both `index.ts` and `server.ts` called `app.listen`, which created startup ambiguity for scripts and
  deployment.                                                                                         
                                                                                                      
  - Kept existing npm scripts unchanged (`dev` and `start` already target `index.ts`)
