### PR TITLE
feat(ui): add premium SVG wave loading screen

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -2,6 +2,8 @@ import "../styles/globals.css";
 import { ThemeProvider } from "./components/ThemeProvider";
 import { ExperimentsProvider } from "./context/ExperimentsContext";
 import EchionAssistant from "@/app/components/Echion";
+import LoadingScreen from "@/components/ui/LoadingScreen";
+import { AnimatePresence } from "framer-motion";
 
 export const metadata = {
   title: "EchoRoom",
@@ -18,6 +20,9 @@ export default function RootLayout({
       <body className="bg-gray-50 dark:bg-slate-900 text-gray-900 dark:text-white transition-colors">
         <ThemeProvider>
           <ExperimentsProvider>
+            <AnimatePresence mode="wait">
+          <LoadingScreen />
+        </AnimatePresence>
             {children}    
             <EchionAssistant />
           </ExperimentsProvider>

--- a/frontend/components/ui/LoadingScreen.tsx
+++ b/frontend/components/ui/LoadingScreen.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { motion, AnimatePresence, useMotionValue, useTransform, animate } from "framer-motion";
+
+export default function LoadingScreen() {
+  const [isLoading, setIsLoading] = useState(true);
+  
+  // Motion value to track the exact percentage from 0 to 100
+  const count = useMotionValue(0);
+  const rounded = useTransform(count, Math.round);
+  
+  // Map the 0-100 percentage directly to the Y-axis position of the SVG wave.
+  // When count is 0, wave is at Y=150 (below text). When count is 100, wave is at Y=-150 (above text).
+  const waveY = useTransform(count, [0, 100], [150, -150]);
+
+  useEffect(() => {
+    // Run the percentage counter and wave fill perfectly in sync over 3.5 seconds
+    const controls = animate(count, 100, {
+      duration: 5,
+      ease: "easeInOut",
+    });
+
+    controls.then(() => {
+      // Hold at 100% for a brief moment before fading out smoothly
+      setTimeout(() => {
+        setIsLoading(false);
+      }, 600);
+    });
+
+    return controls.stop;
+  }, [count]);
+
+  return (
+    <AnimatePresence mode="wait">
+      {isLoading && (
+        <motion.div
+          // Cinematic fade out to reveal your page
+          exit={{ opacity: 0, transition: { duration: 0.8, ease: "easeInOut" } }}
+          className="fixed inset-0 z-[9999] flex items-center justify-center bg-[#050505] overflow-hidden"
+        >
+          {/* Main Container */}
+          <div className="relative w-full max-w-5xl px-4 flex flex-col items-center select-none">
+            
+            {/* SVG Masking System:
+              This is the secret to the NeoLeaf effect. We use the text as a <clipPath>
+              and animate a physical SVG wave shape behind it.
+            */}
+            <svg viewBox="0 0 1000 300" className="w-full h-auto">
+              <defs>
+                <clipPath id="text-mask">
+                  <text
+                    x="50%"
+                    y="50%"
+                    dominantBaseline="middle"
+                    textAnchor="middle"
+                    fontSize="170"
+                    fontWeight="900" // Maximum bold to match the reference
+                    letterSpacing="-0.03em"
+                    fontFamily="ui-sans-serif, system-ui, sans-serif"
+                  >
+                    EchoRoom
+                  </text>
+                </clipPath>
+              </defs>
+
+              {/* Base Layer: Dark Grey Text Background */}
+              <rect
+                x="0"
+                y="0"
+                width="100%"
+                height="100%"
+                fill="#2a2a2a" // This matches the dark grey empty text color in your screenshot
+                clipPath="url(#text-mask)"
+              />
+
+              {/* Foreground Layer: The White Wave Fill */}
+              <motion.g clipPath="url(#text-mask)">
+                <motion.g
+                  // Move left by 800px infinitely. 
+                  // Since the sine wave repeats every 400px, shifting by 800px creates a flawless seamless loop.
+                  animate={{ x: [0, -800] }}
+                  transition={{ repeat: Infinity, ease: "linear", duration: 2.5 }}
+                  style={{ y: waveY }}
+                >
+                  {/* Mathematically perfect repeating sine wave path */}
+                  <path
+                    d="M 0,150 
+                       Q 100,180 200,150 
+                       T 400,150 
+                       T 600,150 
+                       T 800,150 
+                       T 1000,150 
+                       T 1200,150 
+                       T 1400,150 
+                       T 1600,150 
+                       T 1800,150 
+                       T 2000,150 
+                       L 2000,600 L 0,600 Z"
+                    fill="#9CD5FF"
+                  />
+                </motion.g>
+              </motion.g>
+            </svg>
+
+            {/* Loading Percentage Counter */}
+            <div className="absolute bottom-[18%] right-[12%] text-[#e0e0e0] text-sm md:text-base font-sans tracking-widest flex items-center gap-2 font-medium">
+              <span>loading...</span>
+              <div className="w-[3ch] text-right">
+                {/* Framer motion automatically renders the ticking number here */}
+                <motion.span>{rounded}</motion.span>
+              </div>
+              <span>%</span>
+            </div>
+            
+          </div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}


### PR DESCRIPTION
- Implemented a cinematic initial loading screen for EchoRoom.
- Used an SVG text-masking (clipPath) technique for high-performance scaling.
- Added a seamless, mathematically calculated sine wave fill animation.
- Synced the rising wave animation perfectly with a dynamic 0-100% counter using Framer Motion.
<img width="1470" height="956" alt="Screenshot 2026-02-26 at 12 13 00 AM" src="https://github.com/user-attachments/assets/3aae1b7b-c1de-4e55-a227-4f3d44508129" />
