### PR TITLE
Restore server entry point and correct backend bootstrap structure

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -1,25 +1,45 @@
+// backend/src/app.ts
+
 import express, { Request, Response } from "express";
 import cors from "cors";
 import "dotenv/config";
 
+// Route modules
 import ideasRoutes from "./routes/ideas.routes";
 import experimentsRoutes from "./routes/experiments.routes";
 import outcomesRoutes from "./routes/outcomes.routes";
 import reflectionsRoutes from "./routes/reflections.routes";
 import authRoutes from "./routes/auth.routes";
 import commentsRoutes from "./routes/comments.routes";
-import { errorMiddleware, notFoundMiddleware } from "./middleware/error.middleware";
 import likesRoutes from "./routes/likes.routes";
 import insightsRoutes from "./routes/insights.routes";
 
+// Global error handlers
+import { errorMiddleware, notFoundMiddleware } from "./middleware/error.middleware";
+
 const app = express();
 
+/* =========================
+   Global Middleware
+========================= */
+
+// Allow frontend origins
 app.use(cors({ origin: ["http://localhost:3000", "http://localhost:3001"] }));
+
+// Parse JSON request bodies
 app.use(express.json());
+
+/* =========================
+   Health Check Endpoint
+========================= */
 
 app.get("/health", (_req: Request, res: Response) => {
   res.json({ success: true, message: "Backend is running" });
 });
+
+/* =========================
+   Route Registration
+========================= */
 
 app.use("/auth", authRoutes);
 app.use("/ideas", ideasRoutes);
@@ -30,7 +50,14 @@ app.use("/insights", insightsRoutes);
 app.use("/ideas/:ideaId/comments", commentsRoutes);
 app.use("/likes", likesRoutes);
 
+/* =========================
+   Fallback & Error Handling
+========================= */
+
+// Handles unknown routes (404)
 app.use(notFoundMiddleware);
+
+// Handles all uncaught errors
 app.use(errorMiddleware);
 
 export default app;

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,45 +1,8 @@
-// backend/src/app.ts
-import express, { Request, Response } from "express";
-import cors from "cors";
+import app from "./app";
+import "dotenv/config";
 
-import ideasRoutes from "./routes/ideas.routes";
-import experimentsRoutes from "./routes/experiments.routes";
-import outcomesRoutes from "./routes/outcomes.routes";
-import reflectionsRoutes from "./routes/reflections.routes";
-import authRoutes from "./routes/auth.routes";
+const PORT = process.env.PORT || 5000;
 
-const app = express();
-
-// Enables CORS for the frontend running on localhost:3000
-app.use(cors({ origin: "http://localhost:3000" }));
-
-// Parses incoming JSON request bodies
-app.use(express.json());
-
-// Health check endpoint used to verify backend availability
-app.get("/health", (_req: Request, res: Response) => {
-  res.json({ success: true, message: "Backend is running" });
+app.listen(PORT, () => {
+  console.log(`Backend running on http://localhost:${PORT}`);
 });
-
-// Authentication routes (register, login, token refresh, logout)
-app.use("/auth", authRoutes);
-
-// Idea-related routes (create, update, publish, comment, etc.)
-app.use("/ideas", ideasRoutes);
-
-// Experiment lifecycle routes
-app.use("/experiments", experimentsRoutes);
-
-// Outcome tracking routes linked to experiments
-app.use("/outcomes", outcomesRoutes);
-
-// Reflection routes for post-outcome learning
-app.use("/reflections", reflectionsRoutes);
-
-// Global error handler to catch unhandled server errors
-app.use((err: any, _req: Request, res: Response, _next: any) => {
-  console.error("Unhandled error:", err);
-  res.status(500).json({ success: false, message: "Internal server error" });
-});
-
-export default app;


### PR DESCRIPTION
While debugging the backend startup issue, I found that `index.ts` no longer contained the server bootstrap logic (`app.listen`). The file had been modified to only configure and export the Express app, which removed the application entry point.

Because of this, the backend process exited silently without errors.

This PR restores proper separation of concerns:

* `app.ts` → Handles Express configuration (middleware and route registration)
* `index.ts` → Responsible only for starting the server

The backend is now starting correctly and responding to health checks.
