### PR TITLE
Add full Outcome update support with momentum recalculation

### DIFF
--- a/backend/src/routes/outcomes.routes.ts
+++ b/backend/src/routes/outcomes.routes.ts
@@ -6,17 +6,17 @@ import {
   createOutcome,
   getAllOutcomes,
   getOutcomesByExperimentId,
-  updateOutcomeResult
+  updateOutcome
 } from "../services/outcomes.service";
 
 const router = Router();
-
 
 // POST /outcomes
 router.post("/", validateRequest(outcomesSchemas.create), (req: Request, res: Response) => {
   void (async () => {
     try {
       const { experimentId, result, notes, impactLevel, wasExpected } = req.body;
+
       const outcome = await createOutcome(
         experimentId,
         result,
@@ -36,9 +36,7 @@ router.post("/", validateRequest(outcomesSchemas.create), (req: Request, res: Re
       });
     }
   })();
-
 });
-
 
 // GET /outcomes
 router.get("/", (_req: Request, res: Response) => {
@@ -57,36 +55,45 @@ router.get("/", (_req: Request, res: Response) => {
       });
     }
   })();
-
 });
-
 
 // GET /outcomes/:experimentId
-router.get("/:experimentId", validateRequest(outcomesSchemas.listByExperiment), (req: Request, res: Response) => {
-  void (async () => {
-    try {
-      const { experimentId } = req.params;
-      const outcomes = await getOutcomesByExperimentId(experimentId);
+router.get(
+  "/:experimentId",
+  validateRequest(outcomesSchemas.listByExperiment),
+  (req: Request, res: Response) => {
+    void (async () => {
+      try {
+        const { experimentId } = req.params;
+        const outcomes = await getOutcomesByExperimentId(experimentId);
 
-      res.json({
-        success: true,
-        data: outcomes,
-      });
-    } catch (error) {
-      return res.status(500).json({
-        success: false,
-        message: "Failed to fetch outcomes",
-      });
-    }
-  })();
-});
-router.put("/:id", validateRequest(outcomesSchemas.updateResult), (req: Request, res: Response) => {
+        res.json({
+          success: true,
+          data: outcomes,
+        });
+      } catch {
+        return res.status(500).json({
+          success: false,
+          message: "Failed to fetch outcomes",
+        });
+      }
+    })();
+  }
+);
+
+// PUT /outcomes/:id
+router.put("/:id", validateRequest(outcomesSchemas.update), (req: Request, res: Response) => {
   void (async () => {
     try {
       const { id } = req.params;
-      const { result } = req.body;
+      const { result, notes, impactLevel, wasExpected } = req.body;
 
-      const updated = await updateOutcomeResult(id, result);
+      const updated = await updateOutcome(id, {
+        result,
+        notes,
+        impactLevel,
+        wasExpected,
+      });
 
       if (!updated) {
         return res.status(404).json({
@@ -107,4 +114,5 @@ router.put("/:id", validateRequest(outcomesSchemas.updateResult), (req: Request,
     }
   })();
 });
+
 export default router;

--- a/backend/src/services/outcomes.service.ts
+++ b/backend/src/services/outcomes.service.ts
@@ -162,28 +162,39 @@ export const getOutcomesByExperimentId = async (
    Update Outcome Result
 ========================= */
 
-export const updateOutcomeResult = async (
+export const updateOutcome = async (
   id: string,
-  result: string
+  updates: {
+    result?: string;
+    notes?: string;
+    impactLevel?: string;
+    wasExpected?: boolean;
+  }
 ): Promise<Outcome | null> => {
   const existing = await prisma.outcome.findUnique({
     where: { id },
     select: {
+      result: true,
+      notes: true,
       impactLevel: true,
+      wasExpected: true,
     },
   });
 
   if (!existing) return null;
 
-  const newMomentum = computeMomentum(
-    result,
-    existing.impactLevel ?? null
-  );
+  const newResult = updates.result ?? existing.result;
+  const newImpact = updates.impactLevel ?? existing.impactLevel ?? null;
+
+  const newMomentum = computeMomentum(newResult, newImpact);
 
   const updated = await prisma.outcome.update({
     where: { id },
     data: {
-      result,
+      result: newResult,
+      notes: updates.notes ?? existing.notes,
+      impactLevel: newImpact,
+      wasExpected: updates.wasExpected ?? existing.wasExpected,
       momentum: newMomentum,
     },
     select: {
@@ -200,7 +211,6 @@ export const updateOutcomeResult = async (
 
   return toOutcome(updated);
 };
-
 /* =========================
    Check Existence
 ========================= */

--- a/backend/src/validation/request.schemas.ts
+++ b/backend/src/validation/request.schemas.ts
@@ -158,11 +158,9 @@ export const outcomesSchemas = {
       experimentId: z.string().regex(/^[a-fA-F0-9]{24}$/),
       result: z.enum(["SUCCESS", "FAILED", "MIXED"]),
       notes: z.string().optional(),
-
       impactLevel: z
         .enum(["LOW", "MODERATE", "STRONG", "BREAKTHROUGH"])
         .optional(),
-
       wasExpected: z.boolean().optional(),
     }),
   },
@@ -171,11 +169,18 @@ export const outcomesSchemas = {
     params: objectIdParamSchema("experimentId"),
   },
 
-  updateResult: {
+  update: {
     params: objectIdParamSchema("id"),
-    body: z.object({
-      result: z.enum(["SUCCESS", "FAILED", "MIXED"]),
-    }),
+    body: z
+      .object({
+        result: z.enum(["SUCCESS", "FAILED", "MIXED"]).optional(),
+        notes: z.string().optional(),
+        impactLevel: z
+          .enum(["LOW", "MODERATE", "STRONG", "BREAKTHROUGH"])
+          .optional(),
+        wasExpected: z.boolean().optional(),
+      })
+      .strict(),
   },
 };
 


### PR DESCRIPTION
### Summary
- Added full update capability for Outcome (result, notes, impactLevel, wasExpected)
- Implemented automatic momentum recalculation on updates
- Updated validation schema to support advanced fields
- Updated routes to handle full Outcome updates
- Maintained clean service-layer business logic

This enhances Outcome handling and ensures consistent derived data.