### PR TITLE
Fix #296: standardize ObjectId string IDs across API validation and docs                            

### DIFF
--- a/backend/src/middleware/validate.middleware.ts
+++ b/backend/src/middleware/validate.middleware.ts
@@ -29,13 +29,6 @@ export const validateRequest = (schemas: RequestSchemas): RequestHandler => {
   };
 };
 
-export const numericIdParamSchema = (fieldName = "id") =>
-  z.object({
-    [fieldName]: z
-      .string()
-      .regex(/^\d+$/, `${fieldName} must be a valid numeric ID`),
-  });
-
 export const objectIdParamSchema = (fieldName = "id") =>
   z.object({
     [fieldName]: z

--- a/backend/src/validation/request.schemas.ts
+++ b/backend/src/validation/request.schemas.ts
@@ -1,8 +1,5 @@
 import { z } from "zod";
-import {
-  numericIdParamSchema,
-  objectIdParamSchema,
-} from "../middleware/validate.middleware";
+import { objectIdParamSchema } from "../middleware/validate.middleware";
 
 const nonEmptyString = z.string().trim().min(1, "Field is required");
 const ideaComplexitySchema = z.enum(["LOW", "MEDIUM", "HIGH"]);

--- a/backend/test.http
+++ b/backend/test.http
@@ -2,20 +2,33 @@
   POST http://localhost:5000/outcomes                                                                                                                                                                    
   Content-Type: application/json                                                                                                                                                                         
                                                                                                                                                                                                          
-  {                                                                                                                                                                                                      
-    "experimentId":1,                                                                                                                                                                                   
-    "result": "Success",                                                                                                                                                                                 
-    "notes": "Worked in test"                                                                                                                                                                            
-  }                                                                                                                                                                                                      
+  {
+    "experimentId":"64b7f1c9e8a1d2f3c4b5a6d7",
+    "result": "Success",
+    "notes": "Worked in test"
+  }
                                                                                                                                                                                                          
-  ### Create Reflection (match outcomeId from above response, usually 1)                                                                                                                                 
-  POST http://localhost:5000/reflections                                                                                                                                                                 
-  Content-Type: application/json                                                                                                                                                                         
-                                                                                                                                                                                                         
-  {                                                                                                                                                                                                      
-    "outcomeId": 1,                                                                                                                                                                                      
-    "content": "We learned to validate input early."                                                                                                                                                     
-  }                                                                                                                                                                                                      
+  ### Create Reflection (match outcomeId from above response)
+  POST http://localhost:5000/reflections
+  Content-Type: application/json
+
+  {
+    "outcomeId": "64b7f1c9e8a1d2f3c4b5a6d8",
+    "context": { "emotionBefore": 3, "confidenceBefore": 6 },
+    "breakdown": {
+      "whatHappened": "A/B test reached statistical significance.",
+      "whatWorked": "Early user segmentation improved signal quality.",
+      "whatDidntWork": "Sample ramp-up was slower than expected."
+    },
+    "growth": {
+      "lessonLearned": "Define guardrails before launching experiments.",
+      "nextAction": "Automate experiment cohort checks."
+    },
+    "result": { "emotionAfter": 4, "confidenceAfter": 8 },
+    "tags": ["experiment", "validation"],
+    "evidenceLink": "https://example.com/report",
+    "visibility": "public"
+  }
                                                                                                                                                                                                          
   Then verify with:                                                                                                                                                                                      
                                                                                                                                                                                                          

--- a/docs/api.md
+++ b/docs/api.md
@@ -165,7 +165,7 @@ Returns only draft ideas.
 
 ### `GET /ideas/:id`
 
-Returns one idea by numeric ID.
+Returns one idea by ObjectId string.
 
 ### `POST /ideas`
 
@@ -313,7 +313,7 @@ Body (required fields):
   "falsifiability": "...",
   "status": "planned",
   "endDate": "2026-03-10",
-  "linkedIdeaId": 1
+  "linkedIdeaId": "64b7f1c9e8a1d2f3c4b5a6d7"
 }
 ```
 
@@ -337,7 +337,7 @@ Body:
 
 ```json
 {
-  "experimentId": 1,
+  "experimentId": "64b7f1c9e8a1d2f3c4b5a6d7",
   "result": "Success",
   "notes": "Observed lower drop-off"
 }
@@ -375,7 +375,7 @@ Body shape:
 
 ```json
 {
-  "outcomeId": 1,
+  "outcomeId": "64b7f1c9e8a1d2f3c4b5a6d8",
   "context": {
     "emotionBefore": 3,
     "confidenceBefore": 6


### PR DESCRIPTION
## Summary                                                                                          
  This fixes ID type mismatch concerns by aligning API-facing validation/docs with Mongo ObjectId     
  string usage.                                                                                       
                                                                                                      
  ## Changes                                                                                          
  - Removed unused numeric ID validation schema:                                                      
    - `backend/src/middleware/validate.middleware.ts`                                                 
  - Removed unused `numericIdParamSchema` import:                                                     
    - `backend/src/validation/request.schemas.ts`                                                     
  - Updated request examples to use ObjectId strings:                                                 
    - `backend/test.http`                                                                             
  - Updated API documentation from numeric IDs to ObjectId strings:                                   
    - `docs/api.md`                                                                                   
                                                                                                      
  ## Why                                                                                              
  Prisma models use Mongo ObjectIds (`String @db.ObjectId`), so API examples/validation should        
  consistently reflect string IDs end-to-end.                                                         
                                                                                                      
  ## Verification                                                                                     
  - Searched backend/docs for numeric ID parsing and numeric ID examples:                             
    - No remaining `Number(req.params.id)`/`parseInt(req.params.id)` usage                            
    - No remaining numeric-ID wording/examples in updated files