### PR TITLE
add optional idea seeding script and keep runtime unseeded for #312

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -51,6 +51,7 @@ curl http://localhost:5000/health
 - `npm run dev` - Run backend with ts-node
 - `npm run build` - Compile TypeScript to `dist/`
 - `npm run start` - Run compiled server
+- `npm run seed:ideas` - Optional: seed 180 demo ideas into MongoDB
 - `npm run prisma:generate` - Generate Prisma client
 - `npm run prisma:migrate` - Run Prisma migrate (dev)
 - `npm run prisma:push` - Push Prisma schema to DB
@@ -94,3 +95,14 @@ backend/
 - Domain resources are not yet persisted via Prisma
 - Auth/permissions middleware is not consistently enforced across domain routes
 - Insights route files exist but are not mounted in the active server
+
+## Seeding
+
+The backend does not seed idea data automatically at runtime.
+Use `npm run seed:ideas` only when you explicitly want local demo data.
+
+Optional count override:
+
+```bash
+SEED_IDEAS_COUNT=250 npm run seed:ideas
+```

--- a/backend/package.json
+++ b/backend/package.json
@@ -6,6 +6,7 @@
     "dev": "ts-node src/index.ts",
     "build": "tsc",
     "start": "node dist/index.js",
+    "seed:ideas": "npm run build && node dist/scripts/seed-ideas.js",
     "test:experiments-contract": "npm run build && node dist/services/experiments.service.test.js",
     "prisma:generate": "prisma generate",
     "prisma:migrate": "prisma migrate dev",

--- a/backend/src/scripts/seed-ideas.ts
+++ b/backend/src/scripts/seed-ideas.ts
@@ -1,0 +1,66 @@
+import { IdeaComplexity as PrismaIdeaComplexity } from "@prisma/client";
+import prisma from "../lib/prisma";
+
+const DEFAULT_SEED_COUNT = 180;
+const SEED_TITLE_PREFIX = "[SEED] Idea";
+
+const STATUSES = ["draft", "proposed", "experiment", "outcome", "reflection"] as const;
+const COMPLEXITIES: PrismaIdeaComplexity[] = ["LOW", "MEDIUM", "HIGH"];
+
+const parseCount = (): number => {
+  const countFromEnv = process.env.SEED_IDEAS_COUNT;
+  const parsedCount = Number(countFromEnv ?? DEFAULT_SEED_COUNT);
+
+  if (!Number.isInteger(parsedCount) || parsedCount <= 0) {
+    throw new Error("SEED_IDEAS_COUNT must be a positive integer");
+  }
+
+  return parsedCount;
+};
+
+const createSeedPayload = (count: number) => {
+  return Array.from({ length: count }, (_, index) => {
+    const position = index + 1;
+    const status = STATUSES[index % STATUSES.length];
+    const complexity = COMPLEXITIES[index % COMPLEXITIES.length];
+    const normalizedIndex = String(position).padStart(3, "0");
+
+    return {
+      title: `${SEED_TITLE_PREFIX} ${normalizedIndex}`,
+      description: `Generated seed idea #${position} for local development/demo usage.`,
+      status,
+      complexity,
+      version: 1,
+    };
+  });
+};
+
+const seedIdeas = async (): Promise<void> => {
+  const count = parseCount();
+
+  // Idempotent seed behavior: replace only prior seed-generated records.
+  await prisma.idea.deleteMany({
+    where: {
+      title: { startsWith: SEED_TITLE_PREFIX },
+    },
+  });
+
+  const payload = createSeedPayload(count);
+  const result = await prisma.idea.createMany({ data: payload });
+
+  console.log(`Seeded ${result.count} ideas into the database.`);
+};
+
+void (async () => {
+  try {
+    await seedIdeas();
+  } catch (error: unknown) {
+    const message =
+      error instanceof Error ? error.message : "Unknown seed failure";
+
+    console.error(`Failed to seed ideas: ${message}`);
+    process.exitCode = 1;
+  } finally {
+    await prisma.$disconnect();
+  }
+})();


### PR DESCRIPTION
 ## Summary                                                                                          
  Removes runtime dependence on seeded idea data and introduces an explicit, optional seed flow for   
  local/demo usage.                                                                                   
                                                                                                      
  ## Why                                                                                              
  Issue #312 identified that seeded runtime data can leak into behavior and hide real persistence     
  needs. Seeding should be intentional and separate from normal app execution.                        
                                                                                                      
  ## Changes                                                                                          
  - Added optional seed script:                                                                       
    - `backend/src/scripts/seed-ideas.ts`                                                             
  - Added npm command:                                                                                
    - `npm run seed:ideas`                                                                            
  - Updated backend docs to clarify seeding is manual and not runtime:                                
    - `backend/README.md`                                                                             
                                                                                                      
  ## Behavior                                                                                         
  - App runtime does **not** auto-seed ideas.                                                         
  - Seed data is only created when `npm run seed:ideas` is executed.                                  
  - Default seed count is `180`.                                                                      
  - Seed count can be overridden:                                                                     
    - `SEED_IDEAS_COUNT=250 npm run seed:ideas`                                                       
  - Script is idempotent for generated seed rows (replaces prior `[SEED] Idea ...` records).          
                                                                                                      
  ## Verification                                                                                     
  - Confirmed no runtime imports/calls to seed script.                                                
  - Confirmed seeding entrypoint exists only as explicit npm command.