### PR TITLE
docs: align persistence notes with Prisma-backed core entities for #314

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -13,12 +13,12 @@ The backend is no longer a minimal scaffold. It currently includes:
 
 ## Important Data Behavior
 
-Storage is currently hybrid:
+Storage is persisted in MongoDB via Prisma for:
 
-- Persistent in MongoDB (via Prisma): auth users and refresh tokens
-- In-memory only: ideas, comments, experiments, outcomes, reflections
+- auth users and refresh tokens
+- ideas, comments, experiments, outcomes, reflections
 
-On restart, in-memory data is reset.
+Only synthesized insights remain in-memory.
 
 ## Tech Stack
 
@@ -91,6 +91,5 @@ backend/
 
 ## Known Gaps
 
-- Domain resources are not yet persisted via Prisma
 - Auth/permissions middleware is not consistently enforced across domain routes
 - Insights route files exist but are not mounted in the active server

--- a/backend/SETUP.md
+++ b/backend/SETUP.md
@@ -89,10 +89,10 @@ curl -X POST http://localhost:5000/auth/refresh \
 
 ## Current Persistence Reality
 
-- Persistent: auth (`User`, `RefreshToken`) via Prisma + MongoDB
-- In-memory only: ideas, comments, experiments, outcomes, reflections
-
-Backend restart clears in-memory domain data.
+- Persistent via Prisma + MongoDB:
+  - auth (`User`, `RefreshToken`)
+  - ideas, comments, experiments, outcomes, reflections
+- In-memory only: synthesized insights
 
 ## Common Issues
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -420,9 +420,7 @@ Returns reflections for an outcome ID.
 
 ## Persistence Notes
 
-Current persistence is mixed:
+Current persistence:
 
-- Persistent: auth users and refresh tokens (MongoDB via Prisma)
-- Non-persistent: ideas, experiments, outcomes, reflections, comments (in-memory only)
-
-A backend restart clears all non-persistent domain data.
+- Persistent (MongoDB via Prisma): auth users, refresh tokens, ideas, experiments, outcomes, reflections, comments
+- In-memory only: synthesized insights used by the insights service


### PR DESCRIPTION
## Summary                                                                                          
  Core entities (`ideas`, `experiments`, `outcomes`, `reflections`, `comments`) are already persisted 
  via Prisma + MongoDB, but docs still stated they were in-memory and lost on restart.                
                                                                                                      
  ## Changes                                                                                          
  - Updated backend persistence notes in:                                                             
    - `backend/README.md`                                                                             
    - `backend/SETUP.md`                                                                              
    - `docs/api.md`                                                                                   
  - Removed outdated claims that core domain data is in-memory/non-persistent.                        
  - Clarified only synthesized insights remain in-memory.                                             
                                                                                                      
  ## Why                                                                                              
  Issue #314 reports restart data loss for core entities. In current code this is no longer true;     
  stale documentation was misleading and created incorrect operational assumptions.                   
                                                                                                      
  ## Verification                                                                                     
  - Reviewed service implementations:                                                                 
    - `backend/src/services/experiments.service.ts`                                                   
    - `backend/src/services/outcomes.service.ts`                                                      
    - `backend/src/services/reflections.service.ts`                                                   
    - `backend/src/services/comments.service.ts`                                                      
  - Confirmed Prisma CRUD usage for all listed core entities. 