### PR TITLE
fix(frontend): send ObjectId strings for outcome/reflection creation(#318)

### DIFF
--- a/frontend/app/outcomes/new/page.tsx
+++ b/frontend/app/outcomes/new/page.tsx
@@ -29,7 +29,7 @@ export default function NewOutcomePage() {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          experimentId: Number(experimentId),
+          experimentId,
           result,
           notes,
         }),

--- a/frontend/app/reflection/new/page.tsx
+++ b/frontend/app/reflection/new/page.tsx
@@ -10,8 +10,8 @@ import { RetroGrid } from "@/components/ui/retro-grid";
 import SmoothSlider from "@/components/ui/SmoothSlider"; 
 
 interface Outcome {
-  id: number;
-  experimentId: number;
+  id: string;
+  experimentId: string;
   experimentTitle: string;
   result: string;
 }
@@ -48,7 +48,7 @@ export default function NewReflectionPage() {
   });
 
   const [form, setForm] = useState({
-    outcomeId: null as number | null,
+    outcomeId: null as string | null,
     context: {
       emotionBefore: 3,
       confidenceBefore: 5,
@@ -281,7 +281,7 @@ export default function NewReflectionPage() {
                 <select
                   className="w-full p-3 rounded-xl border bg-white dark:bg-zinc-950 focus:ring-2 focus:ring-blue-500 outline-none transition"
                   value={form.outcomeId ?? ""}
-                  onChange={(e) => setForm({ ...form, outcomeId: Number(e.target.value) })}
+                  onChange={(e) => setForm({ ...form, outcomeId: e.target.value || null })}
                 >
                   <option value="">Choose outcome</option>
                   {outcomes.map((o) => (


### PR DESCRIPTION
 ## Summary                                                                                          
  Fixes #318 by removing numeric ID coercion in outcome/reflection creation flows and sending ObjectId
  values as strings to backend endpoints.                                                             
                                                                                                      
  ## Changes                                                                                          
  - `frontend/app/outcomes/new/page.tsx`                                                              
    - Stop casting `experimentId` from query param with `Number(...)`                                 
    - Send raw `experimentId` string in POST `/outcomes` payload                                      
  - `frontend/app/reflection/new/page.tsx`                                                            
    - Update `Outcome` typing from numeric IDs to string IDs                                          
    - Change `form.outcomeId` type from `number | null` to `string | null`                            
    - Stop casting selected outcome with `Number(e.target.value)` and keep string ID                  
                                                                                                      
  ## Why                                                                                              
  Backend request schemas validate ObjectId strings. Numeric coercion caused validation failures and  
  blocked create flows.                                                                               
                                                                                                      
  ## Verification                                                                                     
  - Confirm POST `/outcomes` payload includes `"experimentId": "<24-char-hex>"`                       
  - Confirm POST `/reflections` payload includes `"outcomeId": "<24-char-hex>"`                       
  - Both endpoints return success responses