### PR TITLE
Add Validation Support for Idea Strategic Planning Fields

### DIFF
--- a/backend/src/validation/request.schemas.ts
+++ b/backend/src/validation/request.schemas.ts
@@ -65,3 +65,156 @@ export const ideasSchemas = {
     }),
   },
 };
+
+export const commentsSchemas = {
+  list: {
+    params: objectIdParamSchema("ideaId"),
+  },
+  create: {
+    params: objectIdParamSchema("ideaId"),
+    body: z.object({
+      content: nonEmptyString,
+    }),
+  },
+};
+
+export const experimentsSchemas = {
+  getById: {
+    params: objectIdParamSchema("id"),
+  },
+  create: {
+    body: z.object({
+      title: nonEmptyString,
+      description: nonEmptyString,
+      hypothesis: nonEmptyString,
+      successMetric: nonEmptyString,
+      falsifiability: nonEmptyString,
+      status: experimentStatusSchema,
+      endDate: nonEmptyString,
+      linkedIdeaId: z.string().regex(/^[a-fA-F0-9]{24}$/).optional(),
+    }),
+  },
+  update: {
+    params: objectIdParamSchema("id"),
+    body: z
+      .object({
+        title: nonEmptyString.optional(),
+        description: nonEmptyString.optional(),
+        hypothesis: nonEmptyString.optional(),
+        successMetric: nonEmptyString.optional(),
+        falsifiability: nonEmptyString.optional(),
+        status: experimentStatusSchema.optional(),
+        endDate: nonEmptyString.optional(),
+        linkedIdeaId: z.string().regex(/^[a-fA-F0-9]{24}$/).optional(),
+        outcomeResult: z.enum(["Success", "Failed"]).optional(),
+        progress: z.number().min(0).max(100).optional(),
+      })
+      .strict(),
+  },
+  remove: {
+    params: objectIdParamSchema("id"),
+  },
+};
+
+export const insightsSchemas = {
+  suggestPatterns: {
+    body: z.object({
+      title: nonEmptyString,
+      description: nonEmptyString,
+    }),
+  },
+};
+
+export const reflectionsSchemas = {
+  getById: {
+    params: objectIdParamSchema("id"),
+  },
+  listByOutcome: {
+    params: objectIdParamSchema("outcomeId"),
+  },
+  create: {
+    body: z.object({
+      outcomeId: z.string().regex(/^[a-fA-F0-9]{24}$/),
+      context: z.object({
+        emotionBefore: z.number().min(1).max(5),
+        confidenceBefore: z.number().min(1).max(10),
+      }),
+      breakdown: z.object({
+        whatHappened: nonEmptyString,
+        whatWorked: nonEmptyString,
+        whatDidntWork: nonEmptyString,
+      }),
+      growth: z.object({
+        lessonLearned: nonEmptyString,
+        nextAction: nonEmptyString,
+      }),
+      result: z.object({
+        emotionAfter: z.number().min(1).max(5),
+        confidenceAfter: z.number().min(1).max(10),
+      }),
+      tags: z.array(nonEmptyString).optional(),
+      evidenceLink: z.string().optional(),
+      visibility: z.enum(["private", "public"]),
+    }),
+  },
+};
+
+export const outcomesSchemas = {
+  create: {
+    body: z.object({
+      experimentId: z.string().regex(/^[a-fA-F0-9]{24}$/),
+      result: z.enum(["SUCCESS", "FAILED", "MIXED"]),
+      notes: z.string().optional(),
+      impactLevel: z
+        .enum(["LOW", "MODERATE", "STRONG", "BREAKTHROUGH"])
+        .optional(),
+      wasExpected: z.boolean().optional(),
+    }),
+  },
+
+  listByExperiment: {
+    params: objectIdParamSchema("experimentId"),
+  },
+
+  update: {
+    params: objectIdParamSchema("id"),
+    body: z
+      .object({
+        result: z.enum(["SUCCESS", "FAILED", "MIXED"]).optional(),
+        notes: z.string().optional(),
+        impactLevel: z
+          .enum(["LOW", "MODERATE", "STRONG", "BREAKTHROUGH"])
+          .optional(),
+        wasExpected: z.boolean().optional(),
+      })
+      .strict(),
+  },
+};
+
+export const authSchemas = {
+  register: {
+    body: z.object({
+      email: z.string().email("Valid email is required"),
+      username: nonEmptyString,
+      password: z.string().min(8, "Password must be at least 8 characters"),
+    }),
+  },
+  login: {
+    body: z.object({
+      email: z.string().email("Valid email is required"),
+      password: nonEmptyString,
+    }),
+  },
+  refresh: {
+    body: z.object({
+      refreshToken: nonEmptyString,
+    }),
+  },
+  logout: {
+    body: z
+      .object({
+        refreshToken: nonEmptyString.optional(),
+      })
+      .optional(),
+  },
+};


### PR DESCRIPTION
This PR updates the Idea validation schemas to support the newly introduced strategic planning fields: goal, category, expectedImpact, effort, and timeHorizon.
These fields are now accepted in both Idea creation and Draft creation requests. All new fields are optional to maintain backward compatibility with existing data and workflows.
-> Changes Included
Updated postIdea validation schema
Updated postDraft validation schema
Ensured consistency with backend service and controller updates
Preserved all existing validation logic for other modules
This completes the backend integration for enhanced Idea planning capabilities and prepares the system for future analytics and prioritization features.